### PR TITLE
Increase maxAge to 10 minutes by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ var (
 	excludeSubDirsFlag = flag.String("exclude-subdirs", "", "exclude alerts for this comma-separated list of subdirectories")
 	webhookURLFlag     = flag.String("webhook-url", "", "Slack webhook URL to hit")
 	serveFlag          = flag.Bool("serve", false, "")
-	maxAgeFlag         = flag.Duration("max-age", 3*time.Minute, "Maximum age of events to include")
+	maxAgeFlag         = flag.Duration("max-age", 10*time.Minute, "Maximum age of events to include (for best use, use at least 2X your trigger time)")
 	maxNoticesFlag     = flag.Int("max-notices-per-kind", 5, "Maximum notices per kind (spam reduction)")
 )
 


### PR DESCRIPTION
Addresses race condition where we might miss an event by a few seconds.