### PR TITLE
If p1_name is empty, render a partial tree

### DIFF
--- a/format.go
+++ b/format.go
@@ -44,12 +44,6 @@ func Format(m MessageInput, fancy bool) *slack.Message {
 		content = tableFormat(row.Row, row.VirusTotal, false)
 	}
 
-	if len(content) == 0 {
-		klog.Warningf("%q renderer returned no content, falling back to plain", kind)
-		kind = "plain"
-		content = plainFormat(row.Row, row.VirusTotal)
-	}
-
 	klog.Infof("%q returned %d content blocks: %s", kind, len(content), content)
 
 	titleBlock := slack.NewHeaderBlock(slack.NewTextBlockObject(slack.PlainTextType, title, false, false))

--- a/format.go
+++ b/format.go
@@ -41,7 +41,7 @@ func Format(m MessageInput, fancy bool) *slack.Message {
 	} else {
 		kind = "table"
 		klog.Infof("using table format for %+v", row.Row)
-		content = tableFormat(row.Row, row.VirusTotal)
+		content = tableFormat(row.Row, row.VirusTotal, false)
 	}
 
 	if len(content) == 0 {
@@ -203,8 +203,8 @@ func treeFormat(row Row, vr VTRow) []*slack.SectionBlock {
 
 	klog.Infof("TREE FORMAT (%d bytes): %s", len(sb.String()), sb.String())
 	blocks := []*slack.SectionBlock{slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, sb.String(), false, false), nil, nil)}
-	// print extra fields
-	blocks = append(blocks, tableFormat(row, vr)...)
+	// print extra non-process fields
+	blocks = append(blocks, tableFormat(row, vr, true)...)
 	return blocks
 }
 
@@ -261,7 +261,7 @@ func plainFormat(r Row, vr VTRow) []*slack.SectionBlock {
 	return blocks
 }
 
-func tableFormat(r Row, vr VTRow) []*slack.SectionBlock {
+func tableFormat(r Row, vr VTRow, skipProcesses bool) []*slack.SectionBlock {
 	klog.Infof("table format row: %s\n\nvt: %+v", r, vr)
 
 	keys := []string{}
@@ -278,7 +278,7 @@ func tableFormat(r Row, vr VTRow) []*slack.SectionBlock {
 		v := r[k]
 
 		// handled by treeFormat
-		if strings.HasPrefix(k, "p0_") || strings.HasPrefix(k, "p1_") || strings.HasPrefix(k, "p2_") || strings.HasPrefix(k, "p3_") {
+		if skipProcesses && (strings.HasPrefix(k, "p0_") || strings.HasPrefix(k, "p1_") || strings.HasPrefix(k, "p2_") || strings.HasPrefix(k, "p3_")) {
 			continue
 		}
 

--- a/format.go
+++ b/format.go
@@ -34,7 +34,7 @@ func Format(m MessageInput, fancy bool) *slack.Message {
 		klog.Infof("using plain format for %+v", row.Row)
 		kind = "plain"
 		content = plainFormat(row.Row, row.VirusTotal)
-	} else if row.Row["p0_name"] != "" && row.Row["p1_name"] != "" {
+	} else if row.Row["p0_name"] != "" {
 		kind = "tree"
 		klog.Infof("using tree format for %+v", row.Row)
 		content = treeFormat(row.Row, row.VirusTotal)
@@ -43,6 +43,13 @@ func Format(m MessageInput, fancy bool) *slack.Message {
 		klog.Infof("using table format for %+v", row.Row)
 		content = tableFormat(row.Row, row.VirusTotal)
 	}
+
+	if len(content) == 0 {
+		klog.Warningf("%q renderer returned no content, falling back to plain", kind)
+		kind = "plain"
+		content = plainFormat(row.Row, row.VirusTotal)
+	}
+
 	klog.Infof("%q returned %d content blocks: %s", kind, len(content), content)
 
 	titleBlock := slack.NewHeaderBlock(slack.NewTextBlockObject(slack.PlainTextType, title, false, false))


### PR DESCRIPTION
If event queries are unable to determine parents due to data retention limitations, it can result in an empty Slack notification. For a real-world example:

> I0924 09:39:06.131375       1 format.go:258] table format row: map[exception_key: p0_authority:Software Signing p0_cmd:xattr -p com.apple.rootless /Users/uti.edun/Library/Containers/com.apple.mail/Data/DataVaults p0_cwd: p0_euid:0 p0_name:xattr p0_path:/usr/bin/xattr p0_pid:10343 p0_time:1727169519 p1_authority: p1_cmd: p1_hash: p1_name: p1_path: p1_pid:10342 p2_authority: p2_cmd: p2_hash: p2_name: p2_path: p2_pid:]

Generated an empty set of content blocks:

> I0924 09:39:06.131408       1 format.go:46] "table" returned 0 content blocks: []

With this change, it does generate an appropriate table block:

> I0924 08:04:59.470137   26990 format.go:47] "tree" returned 1 content blocks: [%!s(*slack.SectionBlock=&{section 0xc0004dd140  [] <nil>})]
