### PR TITLE
Increase maxRelationTime (Slack thread re-use) to 12 hours

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -26,7 +26,7 @@ var (
 	maxDupeTime = time.Hour * 24 * 5
 	// Follow-up to threads that are within this time period
 	relationTime    = time.Hour
-	maxRelationTime = time.Hour * 4
+	maxRelationTime = time.Hour * 12
 )
 
 func NewNotifier() Notifier {


### PR DESCRIPTION
This will decrease the number of threads started for similar-looking alerts.