### PR TITLE
scores and threads: improve dynamic range and logging

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -78,7 +78,7 @@ func getRows(ctx context.Context, bucket *storage.BucketHandle, vtc *vt.Client, 
 
 		kind := filepath.Base(filepath.Dir(filepath.Dir(attrs.Name)))
 		if kind != lastKind {
-			klog.Infof("searching %q ...", kind)
+			klog.V(1).Infof("searching %q ...", kind)
 			lastKind = kind
 			maxEmptySize = 0
 		}

--- a/format.go
+++ b/format.go
@@ -25,7 +25,7 @@ func Format(m MessageInput, fancy bool) *slack.Message {
 	}
 
 	t := time.Unix(row.UNIXTime, 0)
-	title := fmt.Sprintf("%s %s — %s @%s %s", KindToEmoji[Kind(row.Score)], row.Kind, id, row.Decorations["computer_name"], t.Format(time.TimeOnly))
+	title := fmt.Sprintf("%s %s — %s @%s %s", scoreToEmoji(row.Score), row.Kind, id, row.Decorations["computer_name"], t.Format(time.TimeOnly))
 
 	var content []*slack.SectionBlock
 	kind := "unknown"

--- a/format.go
+++ b/format.go
@@ -16,21 +16,6 @@ type MessageInput struct {
 	Via []string
 }
 
-func scoreKind(i int) Kind {
-	switch i {
-	case 0:
-		return Unknown
-	case 1:
-		return Harmless
-	case 2:
-		return Suspicious
-	case 3:
-		return PossiblyMalicious
-	default:
-		return Malicious
-	}
-}
-
 func Format(m MessageInput, fancy bool) *slack.Message {
 	row := m.Row
 
@@ -40,7 +25,7 @@ func Format(m MessageInput, fancy bool) *slack.Message {
 	}
 
 	t := time.Unix(row.UNIXTime, 0)
-	title := fmt.Sprintf("%s %s — %s @%s %s", KindToEmoji[scoreKind(row.Score)], row.Kind, id, row.Decorations["computer_name"], t.Format(time.TimeOnly))
+	title := fmt.Sprintf("%s %s — %s @%s %s", KindToEmoji[Kind(row.Score)], row.Kind, id, row.Decorations["computer_name"], t.Format(time.TimeOnly))
 
 	var content []*slack.SectionBlock
 	kind := "unknown"
@@ -189,7 +174,7 @@ func formatVirusTotal(v *VTResult) string {
 		name = name[0:76] + "..."
 	}
 
-	s := fmt.Sprintf("<%s|%s %s>", v.URL, KindToEmoji[v.Kind], name)
+	s := fmt.Sprintf("<%s|%s %s>", v.URL, KindToEmoji[v.Score], name)
 	klog.Infof("VT: %s from %+v", s, v)
 	return s
 }

--- a/format_test.go
+++ b/format_test.go
@@ -91,7 +91,7 @@ func TestFormat(t *testing.T) {
 						URL:   "https://www.virustotal.com/gui/file/1d6c2d03b51d9c06cfa33f32533352785f82697650695822e023d22be9cbcc19",
 						Tags:  []string{"64bits", "elf", "shared-lib"},
 						Found: true,
-						Kind:  Undetected,
+						Score: NoOpinion,
 					},
 					"p2_sha256": &VTResult{
 						URL: "https://www.virustotal.com/gui/file/aac5656e393dc19a801dfd81f3d333e7c6bf7bd288e74009fbadd851b57f7439",

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var (
 	excludeSubDirsFlag = flag.String("exclude-subdirs", "", "exclude alerts for this comma-separated list of subdirectories")
 	channelFlag        = flag.String("channel-id", "", "Slack channel to post to (required for replies)")
 	serveFlag          = flag.Bool("serve", false, "")
-	maxAgeFlag         = flag.Duration("max-age", 60*time.Minute, "Maximum age of events to include (for best use, use at least 2X your trigger time)")
+	maxAgeFlag         = flag.Duration("max-age", 10*time.Minute, "Maximum age of events to include (for best use, use at least 2X your trigger time)")
 	maxNoticesFlag     = flag.Int("max-notices-per-kind", 3, "Maximum notices per kind (spam reduction)")
 )
 

--- a/notify.go
+++ b/notify.go
@@ -71,7 +71,6 @@ func (n *Notifier) findThread(user string, relations map[string]string) (*Thread
 	var related *Thread
 	var via []string
 
-	klog.V(1).Infof("finding thread for %s matching %+v", user, relations)
 	// Rough logic:
 	//
 	// - prefer recent threads that contain the same path
@@ -93,7 +92,7 @@ func (n *Notifier) findThread(user string, relations map[string]string) (*Thread
 
 		if len(matches) > 0 && (related == nil || related.Updated.Before(t.Updated)) {
 			related = t
-			klog.V(1).Infof("newer thread via %s: %+v", matches, related)
+			klog.Infof("found thread for %s via %s: %+v", user, matches, related)
 			via = matches
 		}
 
@@ -104,6 +103,7 @@ func (n *Notifier) findThread(user string, relations map[string]string) (*Thread
 
 	if related == nil && mostRecent != nil {
 		related = mostRecent
+		klog.Infof("found thread for %s via recently: %+v", user, related)
 		via = append(via, "recency")
 	}
 
@@ -122,6 +122,7 @@ func (n *Notifier) findThread(user string, relations map[string]string) (*Thread
 		}
 	}
 
+	klog.Infof("%s: among %d threads, no obvious candidates to follow-up on", user, n.threads[user])
 	return nil, nil
 }
 

--- a/priority_queue.go
+++ b/priority_queue.go
@@ -10,15 +10,6 @@ import (
 // enqueueRow adds rows to the priority queue for later reference
 func enqueueRow(ctx context.Context, pq map[string][]*DecoratedRow, row *DecoratedRow) {
 	device := row.Decorations["computer_name"]
-
-	for _, v := range row.VirusTotal {
-		if v.Kind > Undetected {
-			row.Score = row.Score + (int(v.Kind) - int(Undetected))
-			klog.Infof("increasing score due to virustotal info")
-		}
-	}
-
-	klog.Infof("enqueue[%s]: %s (score %d)", device, row.Kind, row.Score)
 	pq[device] = append(pq[device], row)
 }
 

--- a/score.go
+++ b/score.go
@@ -50,6 +50,8 @@ func scoreRow(ctx context.Context, model *genai.GenerativeModel, row *DecoratedR
 		The 'VirusTotal' struct contains any additional information that VirusTotal discovered about the process or hosts returned by the query. If the VirusTotal struct is empty, it may mean that VirusTotal wasn't available.
 
 		Return a single-word verdict of if the behavior and process tree described by this is benign, undetermined, suspicious, or malicious, followed by a colon and a 5-10 word summary of the row.
+
+		If you are uncertain, your verdict should be undetermined.
 		`,
 		kind))
 

--- a/score.go
+++ b/score.go
@@ -47,11 +47,27 @@ func scoreRow(ctx context.Context, model *genai.GenerativeModel, row *DecoratedR
 	}
 
 	prompt := genai.Text(fmt.Sprintf(`
-		This is the JSON output from Kolide, based on an osquery rule named %q that is part of osquery-defense-kit.
+		This is the JSON output from Kolide, based on an osquery rule named %q that is part of osquery-defense-kit. These JSON rows represent exceptions from the normal baseline in our environment.
 
-		The 'Row' struct is the content returned by the query. If an element starts with p0, it is the child process the alert is centered on. If an element starts with p1_, that is the parent of the process we alerted on. If the element begins with p2_, it is the grandparent process. The grandparent process launches the parent process, which launches the child process.
-		The 'Decorations' struct contains information about the machine the query was run on.
-		The 'VirusTotal' struct contains any additional information that VirusTotal discovered about the process or hosts returned by the query. If the VirusTotal struct is empty, it may mean that VirusTotal wasn't available.
+		Almost all of the time these rows are just benign changes to our environment when people install new software, but we're also very cautious about subtle nation-state attackers getting a foothold in our environment.
+
+		The 'Row' struct is the content returned by the query:
+		- If an element starts with p0, it is the child process the alert is centered on.
+		- If an element starts with p1_, that is the parent of the process we alerted on.
+		- If the element begins with p2_, it is the grandparent process.
+		- The grandparent process launches the parent process, which launches the child process.
+		- If an element is named s_auth or authority, the binary is signed and approved by Apple. It could still be malware, particularly if it is signed by a rare application signer.
+		- If an element is named s_id or identifier, that is the name of the binary that was signed and approved by Apple
+		- Unsigned programs running longer than a day should be regarded with more suspicion than otherwise.
+
+		The 'Decorations' struct contains information about the machine the query was run on. Think of it as a host information struct.
+
+		The 'VirusTotal' struct contains additional information that VirusTotal discovered about the process or IP addresses
+	    returned by the query.
+		- If the VirusTotal struct is empty, it may mean that VirusTotal wasn't available.
+		- A verdict of "undetected_no_opinion" means that VirusTotal did not know about this hash. This is much more common on Linux. It may be a program that the user built for themselves locally.
+		- If a program is harmless_and_known, the tool itself probably benign, but even benign tools can be misused.
+		- If the remote_address is related to GitHub or Microsoft, it probably isn't as suspicious as it looks.
 
 		Return a single-word verdict of if the behavior and process tree described by this is benign, undetermined, suspicious, or malicious, followed by a colon and a 5-10 word summary of the row.
 

--- a/virustotal.go
+++ b/virustotal.go
@@ -13,35 +13,58 @@ type VTResult struct {
 	Found bool
 	Tags  []string
 
-	Name       string
-	Vendor     string
+	KnownHash bool
+	Name      string
+	Vendor    string
+
 	Reputation int64
+
+	MaliciousVotes  int
+	SuspiciousVotes int
+	HarmlessVotes   int
+	UndetectedVotes int
 
 	Country string
 
-	Kind Kind
+	Verdict string
+	Score   Kind
+
+	Raw *vt.Object
 }
 
 type Kind int
 
 const (
-	Unknown Kind = iota
+	NoInformationAvailable Kind = iota
 	HarmlessKnown
 	Harmless
-	Undetected
+	NoOpinion
+	PossiblySuspicious
 	Suspicious
 	PossiblyMalicious
 	Malicious
 )
 
 var KindToEmoji = map[Kind]string{
-	Unknown:           "❓",
-	HarmlessKnown:     "✅",
-	Harmless:          "🔵",
-	Undetected:        "⚫",
-	Suspicious:        "🟡",
-	PossiblyMalicious: "🟠",
-	Malicious:         "👹",
+	NoInformationAvailable: "🤷",
+	HarmlessKnown:          "✅",
+	Harmless:               "🟢",
+	NoOpinion:              "🔵",
+	PossiblySuspicious:     "🟡",
+	Suspicious:             "🟠",
+	PossiblyMalicious:      "🔴",
+	Malicious:              "👹",
+}
+
+var KindToString = map[Kind]string{
+	NoInformationAvailable: "no_information_available",
+	HarmlessKnown:          "harmless_and_known",
+	Harmless:               "harmless",
+	NoOpinion:              "undetected_no_opinion",
+	PossiblySuspicious:     "possibly_suspicious",
+	Suspicious:             "suspicious",
+	PossiblyMalicious:      "possibly_malicious",
+	Malicious:              "malicious",
 }
 
 type VTRow map[string]*VTResult
@@ -84,7 +107,9 @@ func vtInterpret(c *vt.Client, key string) (*VTResult, error) {
 	url = strings.Replace(url, "ip_addresses", "ip-address", 1)
 
 	r := &VTResult{
-		URL: url,
+		URL:     url,
+		Score:   NoInformationAvailable,
+		Verdict: KindToString[NoInformationAvailable],
 	}
 
 	vo, err := vtCacheGet(c, key)
@@ -95,6 +120,7 @@ func vtInterpret(c *vt.Client, key string) (*VTResult, error) {
 	if vo == nil {
 		return r, nil
 	}
+	r.Raw = vo
 	r.Found = true
 
 	ss, err := vo.GetStringSlice("tags")
@@ -128,45 +154,56 @@ func vtInterpret(c *vt.Client, key string) (*VTResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("last_analysis_stats.harmless: %w", err)
 	}
+	r.HarmlessVotes = int(harmless)
 
 	undetected, err := vo.GetInt64("last_analysis_stats.undetected")
 	if err != nil {
 		return nil, fmt.Errorf("last_analysis_stats.undetected: %w", err)
 	}
+	r.UndetectedVotes = int(undetected)
 
 	malicious, err := vo.GetInt64("last_analysis_stats.malicious")
 	if err != nil {
 		return nil, fmt.Errorf("last_analysis_stats.malicious: %w", err)
 	}
+	r.MaliciousVotes = int(malicious)
 
 	suspicious, err := vo.GetInt64("last_analysis_stats.suspicious")
 	if err != nil {
 		return nil, fmt.Errorf("last_analysis_stats.suspicious: %w", err)
 	}
+	r.SuspiciousVotes = int(suspicious)
+
+	klog.Infof("%s reputation: %d [harmless=%d, undetected=%d, malicious=%d, suspicious=%d]", key, reputation, harmless, undetected, malicious, suspicious)
 
 	switch {
-	case malicious > 3:
-		r.Kind = Malicious
+	case malicious > 2:
+		r.Score = Malicious
 	case malicious > 1:
-		r.Kind = PossiblyMalicious
+		r.Score = PossiblyMalicious
+	case suspicious > 2:
+		r.Score = Suspicious
 	case suspicious > 1:
-		r.Kind = Suspicious
+		r.Score = PossiblySuspicious
 	case harmless > 3:
-		r.Kind = Harmless
+		r.Score = Harmless
 	case undetected > 1:
-		r.Kind = Undetected
-	default:
-		r.Kind = Unknown
+		r.Score = NoOpinion
 	}
 
 	// Upgrade known
-	if r.Vendor != "" && r.Kind < Suspicious {
-		r.Kind = HarmlessKnown
+	if r.Vendor != "" && r.Score < Suspicious {
+		r.Score = HarmlessKnown
 	}
 
 	// Downgrade items with a poor reputation
-	if r.Reputation < 0 && r.Kind < Suspicious {
-		r.Kind = Suspicious
+	if r.Reputation < 0 && r.Score < Suspicious {
+		klog.Infof("downgrading to possibly suspicious due to poor reputation: %d", r.Reputation)
+		r.Score = PossiblySuspicious
+	}
+	if r.Reputation < 3 && r.Score < Suspicious {
+		klog.Infof("downgrading to possibly suspicious due to poor reputation: %d", r.Reputation)
+		r.Score = Suspicious
 	}
 
 	as, err := vo.GetString("as_owner")
@@ -195,6 +232,7 @@ func vtInterpret(c *vt.Client, key string) (*VTResult, error) {
 		r.Name = strings.Join(sub, ",")
 	}
 
+	r.Verdict = KindToString[r.Score]
 	return r, nil
 }
 

--- a/virustotal.go
+++ b/virustotal.go
@@ -201,8 +201,8 @@ func vtInterpret(c *vt.Client, key string) (*VTResult, error) {
 		klog.Infof("downgrading to possibly suspicious due to poor reputation: %d", r.Reputation)
 		r.Score = PossiblySuspicious
 	}
-	if r.Reputation < 3 && r.Score < Suspicious {
-		klog.Infof("downgrading to possibly suspicious due to poor reputation: %d", r.Reputation)
+	if r.Reputation < -2 && r.Score < Suspicious {
+		klog.Infof("downgrading to suspicious due to poor reputation: %d", r.Reputation)
 		r.Score = Suspicious
 	}
 

--- a/virustotal.go
+++ b/virustotal.go
@@ -56,6 +56,11 @@ var KindToEmoji = map[Kind]string{
 	Malicious:          "👹",
 }
 
+func scoreToEmoji(score int) string {
+	// score of 0 == Harmless
+	return KindToEmoji[Kind(score)+Harmless]
+}
+
 var KindToString = map[Kind]string{
 	MissingUnknown:     "no_information_available",
 	HarmlessKnown:      "harmless_and_known",

--- a/virustotal.go
+++ b/virustotal.go
@@ -35,7 +35,7 @@ type VTResult struct {
 type Kind int
 
 const (
-	NoInformationAvailable Kind = iota
+	MissingUnknown Kind = iota
 	HarmlessKnown
 	Harmless
 	NoOpinion
@@ -46,25 +46,25 @@ const (
 )
 
 var KindToEmoji = map[Kind]string{
-	NoInformationAvailable: "🤷",
-	HarmlessKnown:          "✅",
-	Harmless:               "🟢",
-	NoOpinion:              "🔵",
-	PossiblySuspicious:     "🟡",
-	Suspicious:             "🟠",
-	PossiblyMalicious:      "🔴",
-	Malicious:              "👹",
+	MissingUnknown:     "🤷",
+	HarmlessKnown:      "✅",
+	Harmless:           "🟢",
+	NoOpinion:          "🔵",
+	PossiblySuspicious: "🟡",
+	Suspicious:         "🟠",
+	PossiblyMalicious:  "🔴",
+	Malicious:          "👹",
 }
 
 var KindToString = map[Kind]string{
-	NoInformationAvailable: "no_information_available",
-	HarmlessKnown:          "harmless_and_known",
-	Harmless:               "harmless",
-	NoOpinion:              "undetected_no_opinion",
-	PossiblySuspicious:     "possibly_suspicious",
-	Suspicious:             "suspicious",
-	PossiblyMalicious:      "possibly_malicious",
-	Malicious:              "malicious",
+	MissingUnknown:     "no_information_available",
+	HarmlessKnown:      "harmless_and_known",
+	Harmless:           "harmless",
+	NoOpinion:          "undetected_no_opinion",
+	PossiblySuspicious: "possibly_suspicious",
+	Suspicious:         "suspicious",
+	PossiblyMalicious:  "possibly_malicious",
+	Malicious:          "malicious",
 }
 
 type VTRow map[string]*VTResult
@@ -108,8 +108,8 @@ func vtInterpret(c *vt.Client, key string) (*VTResult, error) {
 
 	r := &VTResult{
 		URL:     url,
-		Score:   NoInformationAvailable,
-		Verdict: KindToString[NoInformationAvailable],
+		Score:   MissingUnknown,
+		Verdict: KindToString[MissingUnknown],
 	}
 
 	vo, err := vtCacheGet(c, key)


### PR DESCRIPTION
- Vertex benign verdicts can now decrease a score by -1 if - if VirusTotal knows about all of the binaries in the process tree and they are clean.
- Loads more logging to debug scoring & thread determination issues
- More dynamic range to VirusTotal adjustments: new level "PossiblySuspicious" (other levels were renamed for clarity)
 