### PR TITLE
vertex: return response in JSON form, cap budget, remove retry

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,9 +35,8 @@ import (
 )
 
 const (
-	maxBudget  int32  = 24576
-	maxRetries int    = 3
-	modelName  string = "gemini-2.5-flash-preview-04-17"
+	maxBudget int32  = 2048
+	modelName string = "gemini-2.5-flash-preview-04-17"
 )
 
 var (
@@ -93,7 +92,7 @@ func main() {
 		log.Fatalf("genai client: %v", err)
 	}
 
-	if err := scoreRow(ctx, ai, &DecoratedRow{Kind: "ai-test"}); err != nil {
+	if err := scoreRow(ctx, ai, &DecoratedRow{Kind: "1_ai-test"}); err != nil {
 		klog.Exitf("AI test failed: %v\nDo you have 'Vertex AI User' access?", err)
 	}
 

--- a/score.go
+++ b/score.go
@@ -96,15 +96,14 @@ func scoreRow(ctx context.Context, ai *genai.Client, row *DecoratedRow) error {
 
 	// Use the smaller of the row content strings or maxBudget for the thinking budget
 	tb := min(int32(len(strings.Fields(string(bs)))), maxBudget)
-	temp := float32(0)
-	seed := int32(0)
 	klog.Infof("%s:%s - using thinking budget of %d", kind, device, tb)
 	config := &genai.GenerateContentConfig{
 		SystemInstruction: &genai.Content{
 			Parts: []*genai.Part{{Text: prompt}},
 		},
 		// 1 is the default value, but this makes it easy to reference
-		CandidateCount:   1,
+		CandidateCount: 1,
+		// Temperature and Seed are omitted to promote periodic reinterpretation of data
 		ResponseMIMEType: "application/json",
 		ThinkingConfig: &genai.ThinkingConfig{
 			IncludeThoughts: false,

--- a/score.go
+++ b/score.go
@@ -105,8 +105,6 @@ func scoreRow(ctx context.Context, ai *genai.Client, row *DecoratedRow) error {
 		},
 		// 1 is the default value, but this makes it easy to reference
 		CandidateCount:   1,
-		Temperature:      &temp,
-		Seed:             &seed,
 		ResponseMIMEType: "application/json",
 		ThinkingConfig: &genai.ThinkingConfig{
 			IncludeThoughts: false,


### PR DESCRIPTION
The main goal here was to get the thinking into it's own attribute that we can ignore.

I capped the budget because the max was far more than we'd ever need.

I removed the retry to simplify the code - in the rare case that the server fails to respond, it's not critical to retry. If we need retry later, I recommend https://github.com/avast/retry-go with randomized jitter.

Tested locally with:

```
go run . --bucket=chainguard-kolide-logs --prefix=kolide/results/detection --max-age=1h
```